### PR TITLE
Fixed space inside the features flex container to the right of the cards

### DIFF
--- a/style.css
+++ b/style.css
@@ -291,11 +291,13 @@ color: #464747;
 .features__list {
     display: flex;
     flex-wrap: wrap;
-    gap: 15px;
+    --gap: 15px;
+    gap: var(--gap);
 }
 .features__item {
-    width: 32%;
-    padding: 1.5625rem 3rem 0;
+    padding: 1.5625rem 5rem 1.5625rem 1.5625rem;
+    flex: 1 1 calc(33.333% - var(--gap));
+    text-align: justify;
 }
 .features__item-icon {
     margin: 0 0 0.5rem 0;


### PR DESCRIPTION
Was:
![Screen Shot 2023-01-10 at 18 46 35](https://user-images.githubusercontent.com/116911264/211799315-95398095-43c5-4736-84e9-f8a6201caeda.png)
Became:
![Screen Shot 2023-01-11 at 14 47 24](https://user-images.githubusercontent.com/116911264/211799202-bd47e355-ed08-4626-a973-b3e18a15bea8.png)

Fixed #6
