### PR TITLE
Fixed flex elements which was not pressed to the bottom of the card: rating and price

### DIFF
--- a/style.css
+++ b/style.css
@@ -198,6 +198,7 @@ color: #464747;
 .card__container {
     display: flex;
     flex-direction: column;
+    height: 100%;
     padding: 1.125rem;
 }
 .card__direction-of-study {
@@ -221,6 +222,7 @@ color: #464747;
     font-size: 0.75rem;
     line-height: 1.125rem;
     font-weight: 400;
+    flex: 1 1 100%;
 }
 .card__rating-container {
     display: flex;


### PR DESCRIPTION
Was:
![Screen Shot 2023-01-10 at 18 50 37](https://user-images.githubusercontent.com/116911264/211811431-d2fe48a3-f57f-4a20-b7ef-e989623869b5.png)

Became:
![Screen Shot 2023-01-11 at 15 46 16](https://user-images.githubusercontent.com/116911264/211811485-fa3c07de-28e5-4681-afe1-35788005de90.png)

Fixed #5 